### PR TITLE
Use GitHub-hosted runner for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,14 @@ permissions:
 
 jobs:
   build:
-    runs-on: [self-hosted, nixos, hetzner]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clone nostrdb with submodules
         run: |


### PR DESCRIPTION
## Summary
- switch CI to GitHub-hosted runner
- install Nix via cachix action before running tests
