### PR TITLE
Integrate LMDB stores for timeline and contacts

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -181,6 +181,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    contacts_module.addIncludePath(b.path("nostrdb/deps/lmdb"));
     contacts_module.addImport("proto", proto_module);
     contacts_module.addImport("net", net_module);
     contacts_module.addImport("ndb", ndb_module);
@@ -190,6 +191,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    timeline_module.addIncludePath(b.path("nostrdb/deps/lmdb"));
 
     const ingest_module = b.createModule(.{
         .root_source_file = b.path("ingest/lib.zig"),

--- a/cli/main.zig
+++ b/cli/main.zig
@@ -235,8 +235,7 @@ fn printTimeline(
     defer snapshot.deinit();
 
     if (snapshot.entries.len == 0) {
-        try writer.writeAll("No events found.
-");
+        try writer.writeAll("No events found.\n");
         return;
     }
 
@@ -244,8 +243,7 @@ fn printTimeline(
     const display_count = @min(@as(usize, limit), total);
 
     var header_buf: [128]u8 = undefined;
-    const header = try std.fmt.bufPrint(&header_buf, "Timeline ({d} events, showing {d})
-", .{ total, display_count });
+    const header = try std.fmt.bufPrint(&header_buf, "Timeline ({d} events, showing {d})\n", .{ total, display_count });
     try writer.writeAll(header);
 
     var event_buf: [64]u8 = undefined;
@@ -267,11 +265,9 @@ fn printTimeline(
             try writeContentPreview(writer, allocator, record.payload);
         }
 
-        try writer.writeAll("
-");
+        try writer.writeAll("\n");
     }
 }
-
 
 fn encodeHexLower(buf: []u8, bytes: []const u8) []const u8 {
     const charset = "0123456789abcdef";

--- a/contacts/lib.zig
+++ b/contacts/lib.zig
@@ -24,7 +24,6 @@ const LmdbError = error{
     Unexpected,
 };
 
-
 pub const ContactList = struct {
     allocator: Allocator,
     event_id: ContactKey = zero_key,
@@ -43,7 +42,6 @@ pub const ContactList = struct {
         return false;
     }
 };
-;
 
 pub const Options = struct {
     path: []const u8,
@@ -239,7 +237,6 @@ fn mapError(rc: c_int) LmdbError {
         else => error.Unexpected,
     };
 }
-
 
 pub const ContactEvent = struct {
     allocator: Allocator,

--- a/contacts/lib.zig
+++ b/contacts/lib.zig
@@ -3,6 +3,9 @@ const ascii = std.ascii;
 const proto = @import("proto");
 const net = @import("net");
 const ndb = @import("ndb");
+const clmdb = @cImport({
+    @cInclude("lmdb.h");
+});
 
 const log = std.log.scoped(.contacts);
 
@@ -12,73 +15,231 @@ pub const ContactKey = [32]u8;
 
 const zero_key = [_]u8{0} ** 32;
 
+const LmdbError = error{
+    MapFull,
+    NotFound,
+    KeyExist,
+    TxnFull,
+    Corrupt,
+    Unexpected,
+};
+
+
 pub const ContactList = struct {
+    allocator: Allocator,
     event_id: ContactKey = zero_key,
     created_at: u64 = 0,
-    follows: std.AutoHashMap(ContactKey, void),
-
-    pub fn init(allocator: Allocator) ContactList {
-        return .{ .follows = std.AutoHashMap(ContactKey, void).init(allocator) };
-    }
+    follows: []ContactKey = &[_]ContactKey{},
 
     pub fn deinit(self: *ContactList) void {
-        self.follows.deinit();
+        self.allocator.free(self.follows);
+        self.* = undefined;
     }
+
+    pub fn contains(self: ContactList, key: ContactKey) bool {
+        for (self.follows) |follow| {
+            if (std.mem.eql(u8, follow[0..], key[0..])) return true;
+        }
+        return false;
+    }
+};
+;
+
+pub const Options = struct {
+    path: []const u8,
+    map_size: usize = 32 * 1024 * 1024,
 };
 
 pub const Store = struct {
     allocator: Allocator,
-    lists: std.AutoHashMap(ContactKey, ContactList),
+    env: *clmdb.MDB_env,
+    lists_dbi: clmdb.MDB_dbi,
 
-    pub fn init(allocator: Allocator) Store {
-        return .{
+    pub fn init(allocator: Allocator, options: Options) !Store {
+        try ensureDirectory(options.path);
+
+        var env_ptr: ?*clmdb.MDB_env = null;
+        try check(clmdb.mdb_env_create(&env_ptr));
+        errdefer clmdb.mdb_env_close(env_ptr.?);
+
+        try check(clmdb.mdb_env_set_maxdbs(env_ptr.?, 4));
+        try check(clmdb.mdb_env_set_mapsize(env_ptr.?, options.map_size));
+
+        const path_z = try allocator.dupeZ(u8, options.path);
+        defer allocator.free(path_z);
+
+        try check(clmdb.mdb_env_open(env_ptr.?, @ptrCast(path_z.ptr), 0, 0o664));
+
+        var txn_ptr: ?*clmdb.MDB_txn = null;
+        try check(clmdb.mdb_txn_begin(env_ptr.?, null, 0, &txn_ptr));
+        errdefer clmdb.mdb_txn_abort(txn_ptr.?);
+
+        const lists_name = try std.cstr.addNullByte(allocator, "contact_lists");
+        defer allocator.free(lists_name);
+        var lists_dbi: clmdb.MDB_dbi = undefined;
+        try check(clmdb.mdb_dbi_open(txn_ptr.?, @ptrCast(lists_name.ptr), clmdb.MDB_CREATE, &lists_dbi));
+
+        try check(clmdb.mdb_txn_commit(txn_ptr.?));
+
+        return Store{
             .allocator = allocator,
-            .lists = std.AutoHashMap(ContactKey, ContactList).init(allocator),
+            .env = env_ptr.?,
+            .lists_dbi = lists_dbi,
         };
     }
 
     pub fn deinit(self: *Store) void {
-        var it = self.lists.iterator();
-        while (it.next()) |entry| {
-            var list = entry.value_ptr.*;
-            list.deinit();
-        }
-        self.lists.deinit();
+        clmdb.mdb_env_close(self.env);
+        self.* = undefined;
     }
 
-    pub fn get(self: *Store, npub: ContactKey) ?*ContactList {
-        return self.lists.getPtr(npub);
-    }
+    pub fn get(self: *Store, npub: ContactKey) StoreError!?ContactList {
+        var txn_ptr: ?*clmdb.MDB_txn = null;
+        try check(clmdb.mdb_txn_begin(self.env, null, clmdb.MDB_RDONLY, &txn_ptr));
+        defer clmdb.mdb_txn_abort(txn_ptr.?);
 
-    pub fn ensure(self: *Store, npub: ContactKey) !*ContactList {
-        if (self.lists.getPtr(npub)) |existing| return existing;
-        const result = try self.lists.getOrPut(npub);
-        if (!result.found_existing) {
-            result.value_ptr.* = ContactList.init(self.allocator);
+        var key = mdbVal(npub[0..]);
+        var value: clmdb.MDB_val = undefined;
+        const rc = clmdb.mdb_get(txn_ptr.?, self.lists_dbi, &key, &value);
+        if (rc == clmdb.MDB_NOTFOUND) {
+            return null;
         }
-        return result.value_ptr;
+        try check(rc);
+
+        return parseStoredList(self, value);
     }
 
     pub fn applyEvent(self: *Store, event: *ContactEvent) StoreError!void {
         defer event.deinit();
 
-        var list = try self.ensure(event.author);
+        var txn_ptr: ?*clmdb.MDB_txn = null;
+        try check(clmdb.mdb_txn_begin(self.env, null, 0, &txn_ptr));
+        errdefer clmdb.mdb_txn_abort(txn_ptr.?);
 
-        if (list.created_at > event.created_at) return;
-        if (list.created_at == event.created_at) {
-            if (std.mem.lessThan(u8, event.event_id[0..], list.event_id[0..])) {
+        var committed = false;
+        defer if (!committed) clmdb.mdb_txn_abort(txn_ptr.?);
+
+        var key = mdbVal(event.author[0..]);
+        var existing_val: clmdb.MDB_val = undefined;
+        const rc = clmdb.mdb_get(txn_ptr.?, self.lists_dbi, &key, &existing_val);
+        if (rc != clmdb.MDB_NOTFOUND) {
+            try check(rc);
+            const existing = try parseStoredMeta(existing_val);
+            if (existing.created_at > event.created_at) {
+                return;
+            }
+            if (existing.created_at == event.created_at and std.mem.lessThan(u8, event.event_id[0..], existing.event_id[0..])) {
                 return;
             }
         }
 
-        list.follows.clearRetainingCapacity();
+        const follow_count = event.follows.len;
+        if (follow_count > std.math.maxInt(u32)) return error.TooManyFollows;
+        const stored_count = @intCast(u32, follow_count);
+        const total_len = 8 + 32 + 4 + follow_count * ContactKey.len;
+        var buf = try self.allocator.alloc(u8, total_len);
+        defer self.allocator.free(buf);
+
+        std.mem.writeIntLittle(u64, buf[0..8], event.created_at);
+        @memcpy(buf[8..40], event.event_id[0..]);
+        std.mem.writeIntLittle(u32, buf[40..44], stored_count);
+
+        var offset: usize = 44;
         for (event.follows) |follow| {
-            try list.follows.put(follow, {});
+            @memcpy(buf[offset .. offset + ContactKey.len], follow[0..]);
+            offset += ContactKey.len;
         }
-        list.created_at = event.created_at;
-        list.event_id = event.event_id;
+
+        var value = mdbVal(buf);
+        try check(clmdb.mdb_put(txn_ptr.?, self.lists_dbi, &key, &value, 0));
+
+        try check(clmdb.mdb_txn_commit(txn_ptr.?));
+        committed = true;
     }
 };
+
+const StoredMeta = struct {
+    created_at: u64,
+    event_id: ContactKey,
+};
+
+fn parseStoredMeta(val: clmdb.MDB_val) StoreError!StoredMeta {
+    const bytes = mdbSliceConst(val);
+    if (bytes.len < 40) return error.Corrupt;
+    var event_id: ContactKey = undefined;
+    @memcpy(event_id[0..], bytes[8..40]);
+    return StoredMeta{
+        .created_at = std.mem.readIntLittle(u64, bytes[0..8]),
+        .event_id = event_id,
+    };
+}
+
+fn parseStoredList(self: *Store, val: clmdb.MDB_val) StoreError!ContactList {
+    const bytes = mdbSliceConst(val);
+    if (bytes.len < 44) return error.Corrupt;
+    const created_at = std.mem.readIntLittle(u64, bytes[0..8]);
+    var event_id: ContactKey = undefined;
+    @memcpy(event_id[0..], bytes[8..40]);
+    const count = std.mem.readIntLittle(u32, bytes[40..44]);
+    const required = 44 + @as(usize, count) * ContactKey.len;
+    if (bytes.len != required) return error.Corrupt;
+
+    const follows_bytes = bytes[44..];
+    const count_usize = @intCast(usize, count);
+    const follows = try self.allocator.alloc(ContactKey, count_usize);
+    errdefer self.allocator.free(follows);
+
+    var offset: usize = 0;
+    var idx: usize = 0;
+    while (idx < count_usize) : (idx += 1) {
+        @memcpy(follows[idx][0..], follows_bytes[offset .. offset + ContactKey.len]);
+        offset += ContactKey.len;
+    }
+
+    return ContactList{
+        .allocator = self.allocator,
+        .event_id = event_id,
+        .created_at = created_at,
+        .follows = follows,
+    };
+}
+
+fn ensureDirectory(path: []const u8) !void {
+    std.fs.makeDirAbsolute(path) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+}
+
+fn mdbSliceConst(val: clmdb.MDB_val) []const u8 {
+    const ptr: [*]const u8 = @ptrCast(val.mv_data);
+    return ptr[0..val.mv_size];
+}
+
+fn mdbVal(bytes: []const u8) clmdb.MDB_val {
+    return .{
+        .mv_size = bytes.len,
+        .mv_data = @ptrCast(@constCast(bytes.ptr)),
+    };
+}
+
+fn check(rc: c_int) LmdbError!void {
+    if (rc != 0) {
+        return mapError(rc);
+    }
+}
+
+fn mapError(rc: c_int) LmdbError {
+    return switch (rc) {
+        clmdb.MDB_NOTFOUND => error.NotFound,
+        clmdb.MDB_MAP_FULL => error.MapFull,
+        clmdb.MDB_KEYEXIST => error.KeyExist,
+        clmdb.MDB_TXN_FULL => error.TxnFull,
+        clmdb.MDB_CORRUPTED, clmdb.MDB_PAGE_NOTFOUND => error.Corrupt,
+        else => error.Unexpected,
+    };
+}
+
 
 pub const ContactEvent = struct {
     allocator: Allocator,
@@ -193,14 +354,14 @@ pub const Parser = struct {
     }
 };
 
-pub const StoreError = Allocator.Error;
+pub const StoreError = Allocator.Error || LmdbError || error{TooManyFollows};
 
 pub const Fetcher = struct {
     allocator: Allocator,
     store: *Store,
     parser: Parser,
 
-    pub const FetchError = Allocator.Error || net.RelayClientConnectError || net.RelayClientSendError || ndb.Error || proto.ReqBuilderError || Parser.ParseError || error{CompletionTimeout};
+    pub const FetchError = Allocator.Error || net.RelayClientConnectError || net.RelayClientSendError || ndb.Error || proto.ReqBuilderError || Parser.ParseError || StoreError || error{CompletionTimeout};
 
     pub fn init(allocator: Allocator, store: *Store) Fetcher {
         return .{

--- a/tests/timeline_test.zig
+++ b/tests/timeline_test.zig
@@ -8,10 +8,45 @@ fn hexKey(hex: []const u8) [32]u8 {
     return out;
 }
 
+const StoreContext = struct {
+    allocator: std.mem.Allocator,
+    tmp_dir: std.testing.TmpDir,
+    path: []u8,
+    store: timeline.Store,
+
+    fn init(allocator: std.mem.Allocator, max_entries: usize) !StoreContext {
+        var tmp_dir = try std.testing.tmpDir(.{});
+        errdefer tmp_dir.cleanup();
+
+        try tmp_dir.dir.makePath("timeline");
+        const path = try tmp_dir.dir.realpathAlloc(allocator, "timeline");
+        errdefer allocator.free(path);
+
+        var store = try timeline.Store.init(allocator, .{
+            .path = path,
+            .max_entries = max_entries,
+        });
+        errdefer store.deinit();
+
+        return StoreContext{
+            .allocator = allocator,
+            .tmp_dir = tmp_dir,
+            .path = path,
+            .store = store,
+        };
+    }
+
+    fn deinit(self: *StoreContext) void {
+        self.store.deinit();
+        self.allocator.free(self.path);
+        self.tmp_dir.cleanup();
+    }
+};
+
 test "timeline orders entries and respects cap" {
     const allocator = std.testing.allocator;
-    var store = timeline.Store.init(allocator, 3);
-    defer store.deinit();
+    var ctx = try StoreContext.init(allocator, 3);
+    defer ctx.deinit();
 
     const npub = hexKey("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     const author = hexKey("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
@@ -29,21 +64,23 @@ test "timeline orders entries and respects cap" {
     for (events) |ev| {
         const entry = timeline.TimelineEntry{ .event_id = ev.id, .created_at = ev.created_at, .author = author };
         const payload = "{\"id\":\"dummy\"}";
-        try timeline.insertEvent(&store, npub, entry, payload);
+        try timeline.insertEvent(&ctx.store, npub, entry, payload);
     }
 
-    const list = store.getTimeline(npub) orelse return error.TestExpectedResult;
-    try std.testing.expectEqual(@as(usize, 3), list.entries.items.len);
-    try std.testing.expectEqual(@as(u64, 40), list.entries.items[0].created_at);
-    try std.testing.expectEqual(@as(u64, 30), list.entries.items[1].created_at);
-    try std.testing.expectEqual(@as(u64, 20), list.entries.items[2].created_at);
-    try std.testing.expectEqual(@as(u64, 40), list.meta.latest_created_at);
+    var snapshot = try timeline.loadTimeline(&ctx.store, npub);
+    defer snapshot.deinit();
+
+    try std.testing.expectEqual(@as(usize, 3), snapshot.entries.len);
+    try std.testing.expectEqual(@as(u64, 40), snapshot.entries[0].created_at);
+    try std.testing.expectEqual(@as(u64, 30), snapshot.entries[1].created_at);
+    try std.testing.expectEqual(@as(u64, 20), snapshot.entries[2].created_at);
+    try std.testing.expectEqual(@as(u64, 40), snapshot.meta.latest_created_at);
 }
 
 test "timeline skips duplicates" {
     const allocator = std.testing.allocator;
-    var store = timeline.Store.init(allocator, 5);
-    defer store.deinit();
+    var ctx = try StoreContext.init(allocator, 5);
+    defer ctx.deinit();
 
     const npub = hexKey("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     const author = hexKey("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
@@ -51,17 +88,18 @@ test "timeline skips duplicates" {
 
     const entry = timeline.TimelineEntry{ .event_id = id, .created_at = 100, .author = author };
     const payload = "{\"id\":\"x\"}";
-    try timeline.insertEvent(&store, npub, entry, payload);
-    try timeline.insertEvent(&store, npub, entry, payload);
+    try timeline.insertEvent(&ctx.store, npub, entry, payload);
+    try timeline.insertEvent(&ctx.store, npub, entry, payload);
 
-    const list = store.getTimeline(npub) orelse return error.TestExpectedResult;
-    try std.testing.expectEqual(@as(usize, 1), list.entries.items.len);
+    var snapshot = try timeline.loadTimeline(&ctx.store, npub);
+    defer snapshot.deinit();
+    try std.testing.expectEqual(@as(usize, 1), snapshot.entries.len);
 }
 
 test "timeline cap enforced under load" {
     const allocator = std.testing.allocator;
-    var store = timeline.Store.init(allocator, 50);
-    defer store.deinit();
+    var ctx = try StoreContext.init(allocator, 50);
+    defer ctx.deinit();
 
     const npub = hexKey("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     const author = hexKey("1111111111111111111111111111111111111111111111111111111111111111");
@@ -71,13 +109,15 @@ test "timeline cap enforced under load" {
         var buf: [64]u8 = undefined;
         const slice = std.fmt.bufPrint(&buf, "%064x", .{i}) catch unreachable;
         const id = hexKey(slice);
-        const entry = timeline.TimelineEntry{ .event_id = id, .created_at = @as(u64, @intCast(i)), .author = author };
-        try timeline.insertEvent(&store, npub, entry, "{\"kind\":1}");
+        const entry = timeline.TimelineEntry{ .event_id = id, .created_at = @intCast(i), .author = author };
+        try timeline.insertEvent(&ctx.store, npub, entry, "{\"kind\":1}");
     }
 
-    const list = store.getTimeline(npub) orelse return error.TestExpectedResult;
-    try std.testing.expectEqual(@as(usize, 50), list.entries.items.len);
-    try std.testing.expectEqual(@as(u64, 4999), list.meta.latest_created_at);
-    try std.testing.expectEqual(@as(u64, 4999), list.entries.items[0].created_at);
-    try std.testing.expectEqual(@as(u64, 4950), list.entries.items[49].created_at);
+    var snapshot = try timeline.loadTimeline(&ctx.store, npub);
+    defer snapshot.deinit();
+
+    try std.testing.expectEqual(@as(usize, 50), snapshot.entries.len);
+    try std.testing.expectEqual(@as(u64, 4999), snapshot.meta.latest_created_at);
+    try std.testing.expectEqual(@as(u64, 4999), snapshot.entries[0].created_at);
+    try std.testing.expectEqual(@as(u64, 4950), snapshot.entries[49].created_at);
 }

--- a/timeline/lib.zig
+++ b/timeline/lib.zig
@@ -1,4 +1,3 @@
-
 const std = @import("std");
 const clmdb = @cImport({
     @cInclude("lmdb.h");
@@ -227,7 +226,6 @@ pub fn getMeta(store: *Store, npub: PubKey) StoreError!TimelineMeta {
         else => return err,
     };
 }
-
 
 pub fn loadTimeline(store: *Store, npub: PubKey) StoreError!TimelineSnapshot {
     var txn_ptr: ?*clmdb.MDB_txn = null;

--- a/timeline/lib.zig
+++ b/timeline/lib.zig
@@ -1,4 +1,8 @@
+
 const std = @import("std");
+const clmdb = @cImport({
+    @cInclude("lmdb.h");
+});
 
 pub const Allocator = std.mem.Allocator;
 
@@ -25,78 +29,97 @@ pub const EventRecord = struct {
 
 pub const TimelineMeta = struct {
     latest_created_at: u64 = 0,
+    count: usize = 0,
 };
 
-pub const Timeline = struct {
-    entries: std.ArrayListUnmanaged(TimelineEntry) = .{},
-    meta: TimelineMeta = .{},
-
-    pub fn init() Timeline {
-        return .{};
-    }
-
-    pub fn deinit(self: *Timeline, allocator: Allocator) void {
-        self.entries.deinit(allocator);
-    }
-};
-
-pub const EventStore = struct {
+pub const TimelineSnapshot = struct {
     allocator: Allocator,
-    events: std.AutoHashMap(EventId, EventRecord),
+    entries: []TimelineEntry,
+    meta: TimelineMeta,
 
-    pub fn init(allocator: Allocator) EventStore {
-        return .{ .allocator = allocator, .events = std.AutoHashMap(EventId, EventRecord).init(allocator) };
+    pub fn deinit(self: *TimelineSnapshot) void {
+        self.allocator.free(self.entries);
+        self.* = undefined;
     }
+};
 
-    pub fn deinit(self: *EventStore) void {
-        var it = self.events.iterator();
-        while (it.next()) |entry| {
-            var record = entry.value_ptr.*;
-            record.deinit();
-        }
-        self.events.deinit();
-    }
+const LmdbError = error{
+    MapFull,
+    NotFound,
+    KeyExist,
+    TxnFull,
+    Corrupt,
+    Unexpected,
+};
+
+pub const Options = struct {
+    path: []const u8,
+    max_entries: usize,
+    map_size: usize = 128 * 1024 * 1024,
 };
 
 pub const Store = struct {
     allocator: Allocator,
-    timelines: std.AutoHashMap(PubKey, Timeline),
-    events: EventStore,
-    max_entries: usize = 2000,
+    env: *clmdb.MDB_env,
+    timeline_dbi: clmdb.MDB_dbi,
+    events_dbi: clmdb.MDB_dbi,
+    meta_dbi: clmdb.MDB_dbi,
+    max_entries: usize,
 
-    pub fn init(allocator: Allocator, max_entries: usize) Store {
-        return .{
+    pub fn init(allocator: Allocator, options: Options) !Store {
+        try ensureDirectory(options.path);
+
+        var env_ptr: ?*clmdb.MDB_env = null;
+        try check(clmdb.mdb_env_create(&env_ptr));
+        errdefer clmdb.mdb_env_close(env_ptr.?);
+
+        try check(clmdb.mdb_env_set_maxdbs(env_ptr.?, 8));
+        try check(clmdb.mdb_env_set_mapsize(env_ptr.?, options.map_size));
+
+        const path_z = try allocator.dupeZ(u8, options.path);
+        defer allocator.free(path_z);
+
+        try check(clmdb.mdb_env_open(env_ptr.?, @ptrCast(path_z.ptr), 0, 0o664));
+
+        var txn_ptr: ?*clmdb.MDB_txn = null;
+        try check(clmdb.mdb_txn_begin(env_ptr.?, null, 0, &txn_ptr));
+        errdefer clmdb.mdb_txn_abort(txn_ptr.?);
+
+        const timeline_name = try std.cstr.addNullByte(allocator, "timeline_entries");
+        defer allocator.free(timeline_name);
+        var timeline_dbi: clmdb.MDB_dbi = undefined;
+        try check(clmdb.mdb_dbi_open(txn_ptr.?, @ptrCast(timeline_name.ptr), clmdb.MDB_CREATE, &timeline_dbi));
+
+        const events_name = try std.cstr.addNullByte(allocator, "timeline_events");
+        defer allocator.free(events_name);
+        var events_dbi: clmdb.MDB_dbi = undefined;
+        try check(clmdb.mdb_dbi_open(txn_ptr.?, @ptrCast(events_name.ptr), clmdb.MDB_CREATE, &events_dbi));
+
+        const meta_name = try std.cstr.addNullByte(allocator, "timeline_meta");
+        defer allocator.free(meta_name);
+        var meta_dbi: clmdb.MDB_dbi = undefined;
+        try check(clmdb.mdb_dbi_open(txn_ptr.?, @ptrCast(meta_name.ptr), clmdb.MDB_CREATE, &meta_dbi));
+
+        try check(clmdb.mdb_txn_commit(txn_ptr.?));
+
+        return Store{
             .allocator = allocator,
-            .timelines = std.AutoHashMap(PubKey, Timeline).init(allocator),
-            .events = EventStore.init(allocator),
-            .max_entries = max_entries,
+            .env = env_ptr.?,
+            .timeline_dbi = timeline_dbi,
+            .events_dbi = events_dbi,
+            .meta_dbi = meta_dbi,
+            .max_entries = options.max_entries,
         };
     }
 
     pub fn deinit(self: *Store) void {
-        var it = self.timelines.iterator();
-        while (it.next()) |entry| {
-            entry.value_ptr.deinit(self.allocator);
-        }
-        self.timelines.deinit();
-        self.events.deinit();
-    }
-
-    pub fn getTimeline(self: *Store, npub: PubKey) ?*Timeline {
-        return self.timelines.getPtr(npub);
-    }
-
-    pub fn ensureTimeline(self: *Store, npub: PubKey) !*Timeline {
-        if (self.timelines.getPtr(npub)) |existing| return existing;
-        const result = try self.timelines.getOrPut(npub);
-        if (!result.found_existing) {
-            result.value_ptr.* = Timeline.init();
-        }
-        return result.value_ptr;
+        clmdb.mdb_env_close(self.env);
+        self.* = undefined;
     }
 };
 
-pub const InsertError = Allocator.Error;
+pub const InsertError = Allocator.Error || LmdbError;
+pub const StoreError = Allocator.Error || LmdbError;
 
 pub fn insertEvent(
     store: *Store,
@@ -104,74 +127,284 @@ pub fn insertEvent(
     entry: TimelineEntry,
     record_payload: []const u8,
 ) InsertError!void {
-    var timeline = try store.ensureTimeline(npub);
+    var txn_ptr: ?*clmdb.MDB_txn = null;
+    try check(clmdb.mdb_txn_begin(store.env, null, 0, &txn_ptr));
+    errdefer clmdb.mdb_txn_abort(txn_ptr.?);
 
-    // Skip if event already known
-    if (store.events.events.contains(entry.event_id)) {
-        return;
+    var committed = false;
+    defer if (!committed) clmdb.mdb_txn_abort(txn_ptr.?);
+
+    // Write event payload (ignore duplicates)
+    const event_key_buf = entry.event_id;
+    var event_key = mdbVal(event_key_buf[0..]);
+
+    const header_len = 8 + 32;
+    const total_len = header_len + record_payload.len;
+    var event_buf = try store.allocator.alloc(u8, total_len);
+    defer store.allocator.free(event_buf);
+    std.mem.writeIntLittle(u64, event_buf[0..8], entry.created_at);
+    @memcpy(event_buf[8..40], entry.author[0..]);
+    @memcpy(event_buf[40..], record_payload);
+
+    var event_val = mdbVal(event_buf);
+    const put_event_rc = clmdb.mdb_put(txn_ptr.?, store.events_dbi, &event_key, &event_val, clmdb.MDB_NOOVERWRITE);
+    if (put_event_rc != 0 and put_event_rc != clmdb.MDB_KEYEXIST) {
+        return mapError(put_event_rc);
     }
 
-    // Persist event record
-    const payload_copy = try store.allocator.dupe(u8, record_payload);
-    errdefer store.allocator.free(payload_copy);
+    var timeline_key_buf = makeTimelineKey(npub, entry.event_id);
+    var timeline_key = mdbVal(timeline_key_buf[0..]);
 
-    var record = EventRecord{
-        .allocator = store.allocator,
-        .payload = payload_copy,
-        .created_at = entry.created_at,
-        .author = entry.author,
+    var timeline_val_buf: [40]u8 = undefined;
+    std.mem.writeIntLittle(u64, timeline_val_buf[0..8], entry.created_at);
+    @memcpy(timeline_val_buf[8..40], entry.author[0..]);
+    var timeline_val = mdbVal(timeline_val_buf[0..]);
+
+    const put_timeline_rc = clmdb.mdb_put(txn_ptr.?, store.timeline_dbi, &timeline_key, &timeline_val, clmdb.MDB_NOOVERWRITE);
+    if (put_timeline_rc == clmdb.MDB_KEYEXIST) {
+        committed = true;
+        try check(clmdb.mdb_txn_commit(txn_ptr.?));
+        return;
+    } else if (put_timeline_rc != 0) {
+        return mapError(put_timeline_rc);
+    }
+
+    var entries = try loadEntriesInternal(store, txn_ptr.?, npub);
+    defer store.allocator.free(entries);
+    sortEntries(entries);
+
+    const remaining = @min(entries.len, store.max_entries);
+    if (entries.len > store.max_entries) {
+        var idx: usize = remaining;
+        while (idx < entries.len) : (idx += 1) {
+            const to_drop = entries[idx];
+            var drop_key_buf = makeTimelineKey(npub, to_drop.event_id);
+            var drop_key = mdbVal(drop_key_buf[0..]);
+            const del_rc = clmdb.mdb_del(txn_ptr.?, store.timeline_dbi, &drop_key, null);
+            if (del_rc != 0 and del_rc != clmdb.MDB_NOTFOUND) {
+                return mapError(del_rc);
+            }
+
+            var drop_event_key = mdbVal(to_drop.event_id[0..]);
+            const del_event_rc = clmdb.mdb_del(txn_ptr.?, store.events_dbi, &drop_event_key, null);
+            if (del_event_rc != 0 and del_event_rc != clmdb.MDB_NOTFOUND) {
+                return mapError(del_event_rc);
+            }
+        }
+    }
+
+    var meta = TimelineMeta{};
+    meta.count = remaining;
+    if (remaining > 0) {
+        meta.latest_created_at = entries[0].created_at;
+    }
+
+    try writeMeta(store, txn_ptr.?, npub, meta);
+
+    try check(clmdb.mdb_txn_commit(txn_ptr.?));
+    committed = true;
+}
+
+pub fn latestCreatedAt(store: *Store, npub: PubKey) StoreError!u64 {
+    var txn_ptr: ?*clmdb.MDB_txn = null;
+    try check(clmdb.mdb_txn_begin(store.env, null, clmdb.MDB_RDONLY, &txn_ptr));
+    defer clmdb.mdb_txn_abort(txn_ptr.?);
+
+    const meta = readMeta(store, txn_ptr.?, npub) catch |err| switch (err) {
+        error.NotFound => return 0,
+        else => return err,
+    };
+    return meta.latest_created_at;
+}
+
+pub fn getMeta(store: *Store, npub: PubKey) StoreError!TimelineMeta {
+    var txn_ptr: ?*clmdb.MDB_txn = null;
+    try check(clmdb.mdb_txn_begin(store.env, null, clmdb.MDB_RDONLY, &txn_ptr));
+    defer clmdb.mdb_txn_abort(txn_ptr.?);
+
+    return readMeta(store, txn_ptr.?, npub) catch |err| switch (err) {
+        error.NotFound => TimelineMeta{},
+        else => return err,
+    };
+}
+
+
+pub fn loadTimeline(store: *Store, npub: PubKey) StoreError!TimelineSnapshot {
+    var txn_ptr: ?*clmdb.MDB_txn = null;
+    try check(clmdb.mdb_txn_begin(store.env, null, clmdb.MDB_RDONLY, &txn_ptr));
+    defer clmdb.mdb_txn_abort(txn_ptr.?);
+
+    var entries = try loadEntriesInternal(store, txn_ptr.?, npub);
+    errdefer store.allocator.free(entries);
+
+    sortEntries(entries);
+
+    var meta = readMeta(store, txn_ptr.?, npub) catch |err| switch (err) {
+        error.NotFound => TimelineMeta{},
+        else => return err,
     };
 
-    const gop = try store.events.events.getOrPut(entry.event_id);
-    if (gop.found_existing) {
-        record.deinit();
-        return;
+    meta.count = entries.len;
+    meta.latest_created_at = if (entries.len > 0) entries[0].created_at else 0;
+
+    return TimelineSnapshot{
+        .allocator = store.allocator,
+        .entries = entries,
+        .meta = meta,
+    };
+}
+
+pub fn getEvent(store: *Store, id: EventId) StoreError!?EventRecord {
+    var txn_ptr: ?*clmdb.MDB_txn = null;
+    try check(clmdb.mdb_txn_begin(store.env, null, clmdb.MDB_RDONLY, &txn_ptr));
+    defer clmdb.mdb_txn_abort(txn_ptr.?);
+
+    var key = mdbVal(id[0..]);
+    var val: clmdb.MDB_val = undefined;
+    const rc = clmdb.mdb_get(txn_ptr.?, store.events_dbi, &key, &val);
+    if (rc == clmdb.MDB_NOTFOUND) {
+        return null;
     }
-    gop.value_ptr.* = record;
+    try check(rc);
 
-    const allocator = store.allocator;
+    const bytes = mdbSliceConst(val);
+    if (bytes.len < 40) return error.Corrupt;
 
-    // Determine insert position (descending created_at, then event_id)
-    const items = timeline.entries.items;
-    var index: usize = 0;
-    while (index < items.len) : (index += 1) {
-        const existing = items[index];
-        if (existing.created_at < entry.created_at) break;
-        if (existing.created_at == entry.created_at) {
-            if (std.mem.lessThan(u8, existing.event_id[0..], entry.event_id[0..])) break;
-            if (std.mem.eql(u8, existing.event_id[0..], entry.event_id[0..])) {
-                return;
-            }
-        }
+    const created_at = std.mem.readIntLittle(u64, bytes[0..8]);
+    var author: PubKey = undefined;
+    @memcpy(author[0..], bytes[8..40]);
+    const payload_slice = bytes[40..];
+    const payload_copy = try store.allocator.dupe(u8, payload_slice);
+
+    return EventRecord{
+        .allocator = store.allocator,
+        .payload = payload_copy,
+        .created_at = created_at,
+        .author = author,
+    };
+}
+
+fn ensureDirectory(path: []const u8) !void {
+    std.fs.makeDirAbsolute(path) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+}
+
+fn makeTimelineKey(npub: PubKey, event_id: EventId) [64]u8 {
+    var buf: [64]u8 = undefined;
+    @memcpy(buf[0..32], npub[0..]);
+    @memcpy(buf[32..64], event_id[0..]);
+    return buf;
+}
+
+fn sortEntries(entries: []TimelineEntry) void {
+    std.sort.sort(TimelineEntry, entries, {}, lessThanTimeline);
+}
+
+fn lessThanTimeline(_: void, lhs: TimelineEntry, rhs: TimelineEntry) bool {
+    if (lhs.created_at == rhs.created_at) {
+        return std.mem.order(u8, lhs.event_id[0..], rhs.event_id[0..]) == .gt;
+    }
+    return lhs.created_at > rhs.created_at;
+}
+
+fn loadEntriesInternal(store: *Store, txn: *clmdb.MDB_txn, npub: PubKey) StoreError![]TimelineEntry {
+    var cursor_ptr: ?*clmdb.MDB_cursor = null;
+    try check(clmdb.mdb_cursor_open(txn, store.timeline_dbi, &cursor_ptr));
+    defer clmdb.mdb_cursor_close(cursor_ptr.?);
+
+    var entries = std.ArrayList(TimelineEntry).init(store.allocator);
+    errdefer entries.deinit();
+
+    var key_buf: [64]u8 = undefined;
+    @memcpy(key_buf[0..32], npub[0..]);
+    @memset(key_buf[32..], 0);
+
+    var key = mdbVal(key_buf[0..]);
+    var value: clmdb.MDB_val = undefined;
+
+    var rc = clmdb.mdb_cursor_get(cursor_ptr.?, &key, &value, clmdb.MDB_SET_RANGE);
+    while (rc == 0) {
+        const key_bytes = mdbSliceConst(key);
+        if (key_bytes.len != 64) break;
+        if (!std.mem.eql(u8, key_bytes[0..32], npub[0..])) break;
+
+        const value_bytes = mdbSliceConst(value);
+        if (value_bytes.len < 40) return error.Corrupt;
+
+        var entry = TimelineEntry{
+            .event_id = undefined,
+            .created_at = std.mem.readIntLittle(u64, value_bytes[0..8]),
+            .author = undefined,
+        };
+        @memcpy(entry.event_id[0..], key_bytes[32..64]);
+        @memcpy(entry.author[0..], value_bytes[8..40]);
+
+        try entries.append(entry);
+
+        rc = clmdb.mdb_cursor_get(cursor_ptr.?, &key, &value, clmdb.MDB_NEXT);
     }
 
-    try timeline.entries.insert(allocator, index, entry);
-
-    // Trim excess entries
-    while (timeline.entries.items.len > store.max_entries) {
-        const removed_opt = timeline.entries.pop();
-        if (removed_opt) |removed| {
-            if (store.events.events.fetchRemove(removed.event_id)) |kv| {
-                var rec = kv.value;
-                rec.deinit();
-            }
-        } else {
-            break;
-        }
+    if (rc != 0 and rc != clmdb.MDB_NOTFOUND) {
+        return mapError(rc);
     }
 
-    if (timeline.meta.latest_created_at < entry.created_at) {
-        timeline.meta.latest_created_at = entry.created_at;
+    return entries.toOwnedSlice();
+}
+
+fn readMeta(store: *Store, txn: *clmdb.MDB_txn, npub: PubKey) StoreError!TimelineMeta {
+    var key = mdbVal(npub[0..]);
+    var value: clmdb.MDB_val = undefined;
+    const rc = clmdb.mdb_get(txn, store.meta_dbi, &key, &value);
+    if (rc == clmdb.MDB_NOTFOUND) {
+        return error.NotFound;
+    }
+    try check(rc);
+
+    const bytes = mdbSliceConst(value);
+    if (bytes.len < 16) return error.Corrupt;
+
+    return TimelineMeta{
+        .latest_created_at = std.mem.readIntLittle(u64, bytes[0..8]),
+        .count = @intCast(usize, std.mem.readIntLittle(u64, bytes[8..16])),
+    };
+}
+
+fn writeMeta(store: *Store, txn: *clmdb.MDB_txn, npub: PubKey, meta: TimelineMeta) !void {
+    var key = mdbVal(npub[0..]);
+    var buf: [16]u8 = undefined;
+    std.mem.writeIntLittle(u64, buf[0..8], meta.latest_created_at);
+    std.mem.writeIntLittle(u64, buf[8..16], @intCast(u64, meta.count));
+    var value = mdbVal(buf[0..]);
+    try check(clmdb.mdb_put(txn, store.meta_dbi, &key, &value, 0));
+}
+
+fn mdbSliceConst(val: clmdb.MDB_val) []const u8 {
+    const ptr: [*]const u8 = @ptrCast(val.mv_data);
+    return ptr[0..val.mv_size];
+}
+
+fn mdbVal(bytes: []const u8) clmdb.MDB_val {
+    return .{
+        .mv_size = bytes.len,
+        .mv_data = @ptrCast(@constCast(bytes.ptr)),
+    };
+}
+
+fn check(rc: c_int) LmdbError!void {
+    if (rc != 0) {
+        return mapError(rc);
     }
 }
 
-pub fn latestCreatedAt(self: *Store, npub: PubKey) u64 {
-    if (self.timelines.getPtr(npub)) |timeline| {
-        return timeline.meta.latest_created_at;
-    }
-    return 0;
-}
-
-pub fn getEvent(self: *Store, id: EventId) ?*const EventRecord {
-    return self.events.events.getPtr(id);
+fn mapError(rc: c_int) LmdbError {
+    return switch (rc) {
+        clmdb.MDB_NOTFOUND => error.NotFound,
+        clmdb.MDB_MAP_FULL => error.MapFull,
+        clmdb.MDB_KEYEXIST => error.KeyExist,
+        clmdb.MDB_TXN_FULL => error.TxnFull,
+        clmdb.MDB_CORRUPTED, clmdb.MDB_PAGE_NOTFOUND => error.Corrupt,
+        else => error.Unexpected,
+    };
 }


### PR DESCRIPTION
## Summary
- replace the in-memory timeline store with an LMDB-backed implementation and expose helpers to load timeline snapshots and metadata
- persist contacts in LMDB and update the ingest pipeline/CLI/tests to use the new storage APIs
- wire build/test scaffolding to include LMDB headers and update fixtures so tests exercise the LMDB-backed stores

## Testing
- nix develop -c zig build test
