### PR TITLE
CI: unify CI via scripts/ci.sh; Zig 0.15 fixes; add smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,10 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Clone nostrdb with submodules
+      - name: Initialize submodules
         run: |
-          git clone https://github.com/damus-io/nostrdb.git --depth 1
-          cd nostrdb
+          git submodule sync --recursive
           git submodule update --init --recursive --depth 1
-          cd ..
 
       - name: Run CI tests with Nix
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Install Nix
         uses: cachix/install-nix-action@v27
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Initialize submodules
-        run: |
-          git submodule sync --recursive
-          git submodule update --init --recursive --depth 1
+      # submodules are fetched by actions/checkout above
 
       - name: Run CI tests with Nix
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "nostrdb"]
-	path = nostrdb
-	url = git@github.com:justinmoon/nostrdb.git
-	branch = megalith
+    path = nostrdb
+    url = https://github.com/justinmoon/nostrdb.git
+    branch = megalith

--- a/build.zig
+++ b/build.zig
@@ -111,6 +111,8 @@ pub fn build(b: *std.Build) void {
     lib.root_module.addCMacro("ENABLE_MODULE_ECDH", "1");
     lib.root_module.addCMacro("ENABLE_MODULE_SCHNORRSIG", "1");
     lib.root_module.addCMacro("ENABLE_MODULE_EXTRAKEYS", "1");
+    // Avoid UB from unaligned uint32_t loads in CCAN sha256 when Zig enforces alignment
+    lib.root_module.addCMacro("HAVE_UNALIGNED_ACCESS", "0");
 
     // Debug flags similar to build.rs
     switch (optimize) {

--- a/build.zig
+++ b/build.zig
@@ -53,6 +53,7 @@ pub fn build(b: *std.Build) void {
             "-Wno-misleading-indentation",
             "-Wno-unused-function",
             "-Wno-unused-parameter",
+            "-U_FORTIFY_SOURCE",
         },
     });
     // Build CCAN sha256
@@ -63,6 +64,7 @@ pub fn build(b: *std.Build) void {
         .flags = &.{
             "-Wno-unused-function",
             "-Wno-unused-parameter",
+            "-U_FORTIFY_SOURCE",
         },
     });
 
@@ -85,13 +87,14 @@ pub fn build(b: *std.Build) void {
                 "nostrdb/src/bolt11/amount.c",
                 "nostrdb/src/bolt11/hash_u5.c",
             },
-            .flags = &.{
-                "-Wno-sign-compare",
-                "-Wno-misleading-indentation",
-                "-Wno-unused-function",
-                "-Wno-unused-parameter",
-            },
-        });
+        .flags = &.{
+            "-Wno-sign-compare",
+            "-Wno-misleading-indentation",
+            "-Wno-unused-function",
+            "-Wno-unused-parameter",
+            "-U_FORTIFY_SOURCE",
+        },
+    });
     }
 
     // secp256k1 sources and defines
@@ -105,6 +108,7 @@ pub fn build(b: *std.Build) void {
         .flags = &.{
             "-Wno-unused-function",
             "-Wno-unused-parameter",
+            "-U_FORTIFY_SOURCE",
         },
     });
     lib.root_module.addCMacro("SECP256K1_STATIC", "1");

--- a/build.zig
+++ b/build.zig
@@ -18,10 +18,8 @@ pub fn build(b: *std.Build) void {
     lib.linkLibC();
 
     // Common include paths for all C code
-    // On ARM64, add our override directory first to provide a fixed config.h
-    if (target.result.cpu.arch == .aarch64 or target.result.cpu.arch == .aarch64_be) {
-        lib.addIncludePath(b.path("src/override")); // Our config.h override comes first
-    }
+    // Always add our override directory first to provide a fixed config.h
+    lib.addIncludePath(b.path("src/override"));
     lib.addIncludePath(b.path("nostrdb/src"));
     lib.addIncludePath(b.path("nostrdb/src/bindings/c")); // For profile_reader.h
     lib.addIncludePath(b.path("nostrdb/ccan"));
@@ -111,8 +109,6 @@ pub fn build(b: *std.Build) void {
     lib.root_module.addCMacro("ENABLE_MODULE_ECDH", "1");
     lib.root_module.addCMacro("ENABLE_MODULE_SCHNORRSIG", "1");
     lib.root_module.addCMacro("ENABLE_MODULE_EXTRAKEYS", "1");
-    // Avoid UB from unaligned uint32_t loads in CCAN sha256 when Zig enforces alignment
-    lib.root_module.addCMacro("HAVE_UNALIGNED_ACCESS", "0");
 
     // Debug flags similar to build.rs
     switch (optimize) {
@@ -146,6 +142,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    c_module.addIncludePath(b.path("src/override"));
     c_module.addIncludePath(b.path("nostrdb/src"));
     c_module.addIncludePath(b.path("nostrdb/ccan"));
     c_module.addIncludePath(b.path("nostrdb/deps/lmdb"));
@@ -160,9 +157,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    if (target.result.cpu.arch == .aarch64 or target.result.cpu.arch == .aarch64_be) {
-        ndb_module.addIncludePath(b.path("src/override"));
-    }
+    ndb_module.addIncludePath(b.path("src/override"));
     ndb_module.addIncludePath(b.path("nostrdb/src"));
     ndb_module.addIncludePath(b.path("nostrdb/src/bindings/c"));
     ndb_module.addIncludePath(b.path("nostrdb/ccan"));
@@ -244,9 +239,7 @@ pub fn build(b: *std.Build) void {
     ssr_demo.linkLibC();
     ssr_demo.root_module.addImport("ndb", ndb_module);
     ssr_demo.root_module.addImport("proto", proto_module);
-    if (target.result.cpu.arch == .aarch64 or target.result.cpu.arch == .aarch64_be) {
-        ssr_demo.root_module.addIncludePath(b.path("src/override"));
-    }
+    ssr_demo.root_module.addIncludePath(b.path("src/override"));
     ssr_demo.root_module.addIncludePath(b.path("nostrdb/src"));
     ssr_demo.root_module.addIncludePath(b.path("nostrdb/ccan"));
     ssr_demo.root_module.addIncludePath(b.path("nostrdb/deps/lmdb"));
@@ -266,10 +259,7 @@ pub fn build(b: *std.Build) void {
     tests.linkLibC();
 
     // Ensure @cImport("nostrdb.h") resolves for tests
-    // On ARM64, add our override directory first to provide a fixed config.h
-    if (target.result.cpu.arch == .aarch64 or target.result.cpu.arch == .aarch64_be) {
-        tests.root_module.addIncludePath(b.path("src/override"));
-    }
+    tests.root_module.addIncludePath(b.path("src/override"));
     tests.root_module.addIncludePath(b.path("nostrdb/src"));
     tests.root_module.addIncludePath(b.path("nostrdb/ccan"));
     tests.root_module.addIncludePath(b.path("nostrdb/deps/lmdb"));

--- a/build.zig
+++ b/build.zig
@@ -318,6 +318,13 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     tests.root_module.addImport("cli_tests", cli_tests_module);
+
+    const smoke_tests_module = b.createModule(.{
+        .root_source_file = b.path("tests/smoke_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    tests.root_module.addImport("smoke_tests", smoke_tests_module);
     if (target.result.os.tag == .macos) {
         configureAppleSdk(b, tests);
         tests.linkFramework("Security");

--- a/build.zig
+++ b/build.zig
@@ -53,7 +53,6 @@ pub fn build(b: *std.Build) void {
             "-Wno-misleading-indentation",
             "-Wno-unused-function",
             "-Wno-unused-parameter",
-            "-U_FORTIFY_SOURCE",
         },
     });
     // Build CCAN sha256
@@ -64,7 +63,6 @@ pub fn build(b: *std.Build) void {
         .flags = &.{
             "-Wno-unused-function",
             "-Wno-unused-parameter",
-            "-U_FORTIFY_SOURCE",
         },
     });
 
@@ -92,7 +90,6 @@ pub fn build(b: *std.Build) void {
                 "-Wno-misleading-indentation",
                 "-Wno-unused-function",
                 "-Wno-unused-parameter",
-                "-U_FORTIFY_SOURCE",
             },
         });
     }
@@ -108,7 +105,6 @@ pub fn build(b: *std.Build) void {
         .flags = &.{
             "-Wno-unused-function",
             "-Wno-unused-parameter",
-            "-U_FORTIFY_SOURCE",
         },
     });
     lib.root_module.addCMacro("SECP256K1_STATIC", "1");

--- a/build.zig
+++ b/build.zig
@@ -110,7 +110,7 @@ pub fn build(b: *std.Build) void {
     lib.root_module.addCMacro("ENABLE_MODULE_SCHNORRSIG", "1");
     lib.root_module.addCMacro("ENABLE_MODULE_EXTRAKEYS", "1");
     // Ensure FlatCC uses safe loads on all platforms under Zig debug/runtime
-    lib.root_module.addCMacro("FLATCC_ALLOW_UNALIGNED_ACCESS", "0");
+    lib.root_module.addCMacro("PORTABLE_UNALIGNED_ACCESS", "0");
 
     // Debug flags similar to build.rs
     switch (optimize) {

--- a/build.zig
+++ b/build.zig
@@ -87,14 +87,14 @@ pub fn build(b: *std.Build) void {
                 "nostrdb/src/bolt11/amount.c",
                 "nostrdb/src/bolt11/hash_u5.c",
             },
-        .flags = &.{
-            "-Wno-sign-compare",
-            "-Wno-misleading-indentation",
-            "-Wno-unused-function",
-            "-Wno-unused-parameter",
-            "-U_FORTIFY_SOURCE",
-        },
-    });
+            .flags = &.{
+                "-Wno-sign-compare",
+                "-Wno-misleading-indentation",
+                "-Wno-unused-function",
+                "-Wno-unused-parameter",
+                "-U_FORTIFY_SOURCE",
+            },
+        });
     }
 
     // secp256k1 sources and defines

--- a/build.zig
+++ b/build.zig
@@ -109,6 +109,8 @@ pub fn build(b: *std.Build) void {
     lib.root_module.addCMacro("ENABLE_MODULE_ECDH", "1");
     lib.root_module.addCMacro("ENABLE_MODULE_SCHNORRSIG", "1");
     lib.root_module.addCMacro("ENABLE_MODULE_EXTRAKEYS", "1");
+    // Ensure FlatCC uses safe loads on all platforms under Zig debug/runtime
+    lib.root_module.addCMacro("FLATCC_ALLOW_UNALIGNED_ACCESS", "0");
 
     // Debug flags similar to build.rs
     switch (optimize) {

--- a/build.zig
+++ b/build.zig
@@ -14,6 +14,8 @@ pub fn build(b: *std.Build) void {
 
     // Build the C library sources from nostrdb at the pinned commit
     const lib = b.addLibrary(.{ .name = "nostrdb_c", .linkage = .static, .root_module = b.createModule(.{ .target = target, .optimize = optimize }) });
+    // Ensure libc headers and symbols are available when compiling C sources
+    lib.linkLibC();
 
     // Common include paths for all C code
     // On ARM64, add our override directory first to provide a fixed config.h
@@ -212,6 +214,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    megalith.linkLibC();
     megalith.root_module.addImport("proto", proto_module);
     megalith.root_module.addImport("net", net_module);
     megalith.root_module.addImport("contacts", contacts_module);
@@ -236,6 +239,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    ssr_demo.linkLibC();
     ssr_demo.root_module.addImport("ndb", ndb_module);
     ssr_demo.root_module.addImport("proto", proto_module);
     if (target.result.cpu.arch == .aarch64 or target.result.cpu.arch == .aarch64_be) {
@@ -257,6 +261,7 @@ pub fn build(b: *std.Build) void {
 
     // Unit tests target for Zig wrappers and Phase 1 tests
     const tests = b.addTest(.{ .root_module = b.createModule(.{ .root_source_file = b.path("src/test.zig"), .target = target, .optimize = optimize }) });
+    tests.linkLibC();
 
     // Ensure @cImport("nostrdb.h") resolves for tests
     // On ARM64, add our override directory first to provide a fixed config.h

--- a/cli/main.zig
+++ b/cli/main.zig
@@ -259,7 +259,8 @@ fn printTimeline(
         const prefix = try std.fmt.bufPrint(&line_buf, "[{d:>3}] {d}  {s} {s}", .{ idx, entry.created_at, event_hex, author_hex });
         try writer.writeAll(prefix);
 
-        if (try timeline.getEvent(store, entry.event_id)) |record| {
+        if (try timeline.getEvent(store, entry.event_id)) |rec_val| {
+            var record = rec_val; // make mutable for deinit()
             defer record.deinit();
             try writer.writeAll("  ");
             try writeContentPreview(writer, allocator, record.payload);

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== NostrDB Zig CI ==="
+echo ""
+
+# Ensure we're in the project directory (has build.zig)
+if [ ! -f "build.zig" ]; then
+  echo "Error: build.zig not found. Please run from project root."
+  exit 1
+fi
+
+echo "→ Checking Zig version..."
+if ! command -v zig >/dev/null 2>&1; then
+  echo "zig not found in PATH. Ensure you run via 'nix run .#ci' or have zig installed."
+  exit 1
+fi
+zig version
+echo ""
+
+# Prefer CC/AR from PATH if available, else fall back to stdenv defaults set by the Nix wrapper
+export CC="${CC:-$(command -v cc || true)}"
+export AR="${AR:-$(command -v ar || true)}"
+
+# On Linux, help Zig find a basic libc if necessary
+if [[ "${OSTYPE:-}" == linux* ]]; then
+  export ZIG_LIBC_TXT=$(mktemp)
+  cat > "$ZIG_LIBC_TXT" << 'LIBC_EOF'
+include_dir=/usr/include
+sys_include_dir=/usr/include
+crt_dir=/usr/lib
+msvc_lib_dir=
+kernel32_lib_dir=
+gcc_dir=
+LIBC_EOF
+  echo "Created libc config at $ZIG_LIBC_TXT"
+fi
+echo ""
+
+echo "→ Formatting check..."
+echo "Checking if code is properly formatted..."
+if ! zig fmt --check . 2>/dev/null; then
+  echo "✗ Code formatting issues found!"
+  echo "  Run 'zig fmt .' to fix formatting"
+  exit 1
+fi
+echo "✓ Code formatting OK"
+echo ""
+
+echo "→ Ensuring nostrdb sources are present..."
+if [ -f "nostrdb/src/nostrdb.c" ]; then
+  echo "✓ nostrdb sources already present"
+else
+  echo "nostrdb submodule not present; attempting https clone..."
+  # First, try submodule with https override
+  git config --global url.https://github.com/.insteadof ssh://git@github.com/ || true
+  git config --global url.https://github.com/.insteadof git@github.com: || true
+  if git submodule update --init --recursive; then
+    echo "✓ submodule initialized via https override"
+  else
+    echo "Submodule init failed; falling back to direct clone of megalith branch"
+    rm -rf nostrdb || true
+    git clone --depth 1 --branch megalith https://github.com/justinmoon/nostrdb.git nostrdb
+  fi
+fi
+
+# Validate required C dependencies in submodule
+if [ ! -f "nostrdb/deps/lmdb/mdb.c" ] || [ ! -f "nostrdb/deps/lmdb/midl.c" ]; then
+  echo "✗ LMDB sources not found under nostrdb/deps/lmdb"
+  exit 1
+fi
+echo "✓ LMDB headers and sources found"
+echo ""
+
+echo "→ Building (debug) ..."
+# Nix injects flags that Zig's C stage may not understand; sanitize them
+unset NIX_CFLAGS_COMPILE NIX_CFLAGS_LINK NIX_LDFLAGS || true
+zig build
+echo "✓ Build OK"
+echo ""
+
+echo "→ Building megalith + ssr-demo ..."
+zig build megalith
+zig build ssr-demo
+echo "✓ megalith and ssr-demo built"
+echo ""
+
+echo "→ Running tests (includes smoke) ..."
+zig build test
+echo "✓ Tests passed"
+echo ""
+
+echo "→ Additional checks..."
+TODO_COUNT=$(grep -r "TODO\|FIXME" --include="*.zig" . 2>/dev/null | wc -l || echo "0")
+if [ "$TODO_COUNT" -gt 0 ]; then
+  echo "ℹ Found $TODO_COUNT TODO/FIXME comments"
+fi
+UNREACHABLE_COUNT=$(grep -r "unreachable" --include="*.zig" . 2>/dev/null | wc -l || echo "0")
+if [ "$UNREACHABLE_COUNT" -gt 0 ]; then
+  echo "ℹ Found $UNREACHABLE_COUNT uses of 'unreachable'"
+fi
+
+echo ""
+echo "=== ✓ CI passed successfully! ==="

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -34,6 +34,8 @@ kernel32_lib_dir=
 gcc_dir=
 LIBC_EOF
   echo "Created libc config at $ZIG_LIBC_TXT"
+  # Ensure zig picks this up during build/cc
+  export ZIG_LIBC="$ZIG_LIBC_TXT"
 fi
 echo ""
 

--- a/src/profile_shim.c
+++ b/src/profile_shim.c
@@ -98,7 +98,8 @@ int ndb_profile_record_is_valid(const void* record, size_t len) {
     
     // Check root offset is within bounds
     // Flatbuffers start with a 4-byte offset to the root table
-    uint32_t root_offset = *(uint32_t*)buffer;
+    uint32_t root_offset;
+    memcpy(&root_offset, buffer, sizeof(root_offset));
     if (root_offset + 4 > len) return 0;
     
     // The root table is at buffer + root_offset + 4
@@ -108,14 +109,16 @@ int ndb_profile_record_is_valid(const void* record, size_t len) {
     
     // Check vtable offset (first field of table)
     // This is a signed offset pointing backwards to the vtable
-    int32_t vtable_soffset = *(int32_t*)root_table;
+    int32_t vtable_soffset;
+    memcpy(&vtable_soffset, root_table, sizeof(vtable_soffset));
     if (vtable_soffset >= 0) return 0;  // Must be negative (points backwards)
     
     const uint8_t* vtable = root_table - vtable_soffset;
     if (vtable < buffer || (size_t)(vtable - buffer) >= len) return 0;
     
     // Check vtable size (first field of vtable)
-    uint16_t vtable_size = *(uint16_t*)vtable;
+    uint16_t vtable_size;
+    memcpy(&vtable_size, vtable, sizeof(vtable_size));
     if (vtable_size < 4) return 0;  // Min vtable size (size + object_size)
     if ((size_t)(vtable - buffer) + vtable_size > len) return 0;
     

--- a/src/test.zig
+++ b/src/test.zig
@@ -8,6 +8,7 @@ test {
     _ = @import("contacts_tests");
     _ = @import("timeline_tests");
     _ = @import("ingest_tests");
+    _ = @import("smoke_tests");
     _ = @import("cli_tests");
     _ = @import("test_phase5.zig");
 }

--- a/tests/smoke_test.zig
+++ b/tests/smoke_test.zig
@@ -1,0 +1,94 @@
+const std = @import("std");
+const net = @import("net");
+const contacts = @import("contacts");
+const timeline = @import("timeline");
+const ingest = @import("ingest");
+const ndb = @import("ndb");
+
+const Response = net.MockRelayResponse;
+const ResponseBatch = net.MockRelayResponseBatch;
+
+fn reservePort() u16 {
+    // Simple deterministic port chooser for CI
+    const base: u16 = 41000;
+    const offset: u16 = @intCast(std.time.milliTimestamp() % 1000);
+    return base +% offset;
+}
+
+fn hexKey(hex: []const u8) [32]u8 {
+    var out: [32]u8 = undefined;
+    const written = std.fmt.hexToBytes(out[0..], hex) catch unreachable;
+    std.debug.assert(written == 32);
+    return out;
+}
+
+const EOSE_TEMPLATE = "[\"EOSE\",\"{SUB_ID}\"]";
+
+test "smoke: pipeline completes with EOSE only (fast)" {
+    const allocator = std.testing.allocator;
+
+    var tmp_dir = try std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const db_path = try tmp_dir.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(db_path);
+
+    var cfg = ndb.Config.initDefault();
+    var db = try ndb.Ndb.init(allocator, db_path, &cfg);
+    defer db.deinit();
+
+    try tmp_dir.dir.makePath("contacts");
+    const contacts_path = try tmp_dir.dir.realpathAlloc(allocator, "contacts");
+    defer allocator.free(contacts_path);
+
+    var contacts_store = try contacts.Store.init(allocator, .{ .path = contacts_path });
+    defer contacts_store.deinit();
+
+    try tmp_dir.dir.makePath("timeline");
+    const timeline_path = try tmp_dir.dir.realpathAlloc(allocator, "timeline");
+    defer allocator.free(timeline_path);
+
+    var timeline_store = try timeline.Store.init(allocator, .{ .path = timeline_path, .max_entries = 8 });
+    defer timeline_store.deinit();
+
+    // Author and a single follow
+    const npub = hexKey("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    const follow = hexKey("3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d");
+    var follows = try allocator.alloc(contacts.ContactKey, 1);
+    follows[0] = follow;
+    var contact_event = contacts.ContactEvent{
+        .allocator = allocator,
+        .author = npub,
+        .created_at = 1,
+        .event_id = hexKey("0101010101010101010101010101010101010101010101010101010101010101"),
+        .follows = follows,
+    };
+    try contacts_store.applyEvent(&contact_event);
+
+    var pipeline = ingest.Pipeline.init(allocator, npub, 8, &contacts_store, &timeline_store, &db);
+
+    // Two-phase EOSE: initial (triggers resubscribe), then live (finishes)
+    const batches = [_]ResponseBatch{
+        .{ .messages = &.{Response{ .text = EOSE_TEMPLATE }} },
+        .{ .messages = &.{Response{ .text = EOSE_TEMPLATE }} },
+    };
+
+    const port = reservePort();
+    var server = try net.MockRelayServer.init(.{
+        .allocator = allocator,
+        .port = port,
+        .batches = &batches,
+    });
+    defer server.deinit();
+    try server.start();
+
+    const relay_url = try server.address(allocator);
+    defer allocator.free(relay_url);
+
+    try pipeline.run(&.{relay_url});
+
+    // Verify nothing was ingested (no events), and it completed promptly
+    var snapshot = try timeline.loadTimeline(&timeline_store, npub);
+    defer snapshot.deinit();
+    try std.testing.expectEqual(@as(usize, 0), snapshot.entries.len);
+}

--- a/timeline/lib.zig
+++ b/timeline/lib.zig
@@ -84,17 +84,17 @@ pub const Store = struct {
         try check(clmdb.mdb_txn_begin(env_ptr.?, null, 0, &txn_ptr));
         errdefer clmdb.mdb_txn_abort(txn_ptr.?);
 
-        const timeline_name = try std.cstr.addNullByte(allocator, "timeline_entries");
+        const timeline_name = try allocator.dupeZ(u8, "timeline_entries");
         defer allocator.free(timeline_name);
         var timeline_dbi: clmdb.MDB_dbi = undefined;
         try check(clmdb.mdb_dbi_open(txn_ptr.?, @ptrCast(timeline_name.ptr), clmdb.MDB_CREATE, &timeline_dbi));
 
-        const events_name = try std.cstr.addNullByte(allocator, "timeline_events");
+        const events_name = try allocator.dupeZ(u8, "timeline_events");
         defer allocator.free(events_name);
         var events_dbi: clmdb.MDB_dbi = undefined;
         try check(clmdb.mdb_dbi_open(txn_ptr.?, @ptrCast(events_name.ptr), clmdb.MDB_CREATE, &events_dbi));
 
-        const meta_name = try std.cstr.addNullByte(allocator, "timeline_meta");
+        const meta_name = try allocator.dupeZ(u8, "timeline_meta");
         defer allocator.free(meta_name);
         var meta_dbi: clmdb.MDB_dbi = undefined;
         try check(clmdb.mdb_dbi_open(txn_ptr.?, @ptrCast(meta_name.ptr), clmdb.MDB_CREATE, &meta_dbi));
@@ -141,7 +141,7 @@ pub fn insertEvent(
     const total_len = header_len + record_payload.len;
     var event_buf = try store.allocator.alloc(u8, total_len);
     defer store.allocator.free(event_buf);
-    std.mem.writeIntLittle(u64, event_buf[0..8], entry.created_at);
+    std.mem.writeInt(u64, event_buf[0..8], entry.created_at, .little);
     @memcpy(event_buf[8..40], entry.author[0..]);
     @memcpy(event_buf[40..], record_payload);
 
@@ -155,7 +155,7 @@ pub fn insertEvent(
     var timeline_key = mdbVal(timeline_key_buf[0..]);
 
     var timeline_val_buf: [40]u8 = undefined;
-    std.mem.writeIntLittle(u64, timeline_val_buf[0..8], entry.created_at);
+    std.mem.writeInt(u64, timeline_val_buf[0..8], entry.created_at, .little);
     @memcpy(timeline_val_buf[8..40], entry.author[0..]);
     var timeline_val = mdbVal(timeline_val_buf[0..]);
 
@@ -168,7 +168,7 @@ pub fn insertEvent(
         return mapError(put_timeline_rc);
     }
 
-    var entries = try loadEntriesInternal(store, txn_ptr.?, npub);
+    const entries = try loadEntriesInternal(store, txn_ptr.?, npub);
     defer store.allocator.free(entries);
     sortEntries(entries);
 
@@ -232,7 +232,7 @@ pub fn loadTimeline(store: *Store, npub: PubKey) StoreError!TimelineSnapshot {
     try check(clmdb.mdb_txn_begin(store.env, null, clmdb.MDB_RDONLY, &txn_ptr));
     defer clmdb.mdb_txn_abort(txn_ptr.?);
 
-    var entries = try loadEntriesInternal(store, txn_ptr.?, npub);
+    const entries = try loadEntriesInternal(store, txn_ptr.?, npub);
     errdefer store.allocator.free(entries);
 
     sortEntries(entries);
@@ -268,7 +268,7 @@ pub fn getEvent(store: *Store, id: EventId) StoreError!?EventRecord {
     const bytes = mdbSliceConst(val);
     if (bytes.len < 40) return error.Corrupt;
 
-    const created_at = std.mem.readIntLittle(u64, bytes[0..8]);
+    const created_at = std.mem.readInt(u64, bytes[0..8], .little);
     var author: PubKey = undefined;
     @memcpy(author[0..], bytes[8..40]);
     const payload_slice = bytes[40..];
@@ -297,7 +297,19 @@ fn makeTimelineKey(npub: PubKey, event_id: EventId) [64]u8 {
 }
 
 fn sortEntries(entries: []TimelineEntry) void {
-    std.sort.sort(TimelineEntry, entries, {}, lessThanTimeline);
+    var i: usize = 0;
+    while (i < entries.len) : (i += 1) {
+        var j: usize = i;
+        while (j > 0) : (j -= 1) {
+            if (lessThanTimeline({}, entries[j], entries[j - 1])) {
+                const tmp = entries[j - 1];
+                entries[j - 1] = entries[j];
+                entries[j] = tmp;
+            } else {
+                break;
+            }
+        }
+    }
 }
 
 fn lessThanTimeline(_: void, lhs: TimelineEntry, rhs: TimelineEntry) bool {
@@ -312,7 +324,7 @@ fn loadEntriesInternal(store: *Store, txn: *clmdb.MDB_txn, npub: PubKey) StoreEr
     try check(clmdb.mdb_cursor_open(txn, store.timeline_dbi, &cursor_ptr));
     defer clmdb.mdb_cursor_close(cursor_ptr.?);
 
-    var entries = std.ArrayList(TimelineEntry).init(store.allocator);
+    var entries = std.array_list.Managed(TimelineEntry).init(store.allocator);
     errdefer entries.deinit();
 
     var key_buf: [64]u8 = undefined;
@@ -333,7 +345,7 @@ fn loadEntriesInternal(store: *Store, txn: *clmdb.MDB_txn, npub: PubKey) StoreEr
 
         var entry = TimelineEntry{
             .event_id = undefined,
-            .created_at = std.mem.readIntLittle(u64, value_bytes[0..8]),
+            .created_at = std.mem.readInt(u64, value_bytes[0..8], .little),
             .author = undefined,
         };
         @memcpy(entry.event_id[0..], key_bytes[32..64]);
@@ -364,16 +376,16 @@ fn readMeta(store: *Store, txn: *clmdb.MDB_txn, npub: PubKey) StoreError!Timelin
     if (bytes.len < 16) return error.Corrupt;
 
     return TimelineMeta{
-        .latest_created_at = std.mem.readIntLittle(u64, bytes[0..8]),
-        .count = @intCast(usize, std.mem.readIntLittle(u64, bytes[8..16])),
+        .latest_created_at = std.mem.readInt(u64, bytes[0..8], .little),
+        .count = @as(usize, @intCast(std.mem.readInt(u64, bytes[8..16], .little))),
     };
 }
 
 fn writeMeta(store: *Store, txn: *clmdb.MDB_txn, npub: PubKey, meta: TimelineMeta) !void {
     var key = mdbVal(npub[0..]);
     var buf: [16]u8 = undefined;
-    std.mem.writeIntLittle(u64, buf[0..8], meta.latest_created_at);
-    std.mem.writeIntLittle(u64, buf[8..16], @intCast(u64, meta.count));
+    std.mem.writeInt(u64, buf[0..8], meta.latest_created_at, .little);
+    std.mem.writeInt(u64, buf[8..16], @as(u64, @intCast(meta.count)), .little);
     var value = mdbVal(buf[0..]);
     try check(clmdb.mdb_put(txn, store.meta_dbi, &key, &value, 0));
 }


### PR DESCRIPTION
Implements CI improvements from PLAN_V3.md:

- Move to a single `scripts/ci.sh` entrypoint for CI
- Build and test under Nix; sanitize `NIX_CFLAGS` for C build
- Add `tests/smoke_test.zig` and wire `src/test.zig`
- Fix Zig 0.15 compatibility (casts, mem read/write, sort API)
- Keep `build.zig` and libs consistent; minor refactors

Diff summary:

```
$(git diff --stat origin/master..HEAD)
```

This PR should make CI deterministic across Nix and local runs.